### PR TITLE
add support for vmseries-flex running 10.1.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 **The Purpose of this template is to allow you to launch a second VM-Series into an existing resource group because the Azure Marketplace will not allow this.**   
 
-You will still be responsible for configuring your own Azure HA settings within the Azure Portal and the VM-Series firewall. Please refer to the VM-Series deployment guide for 9.0 for configuration details. [DEPLOYMENT GUIDE](https://docs.paloaltonetworks.com/vm-series/9-0/vm-series-deployment/set-up-the-vm-series-firewall-on-azure/configure-activepassive-ha-for-vm-series-firewall-on-azure.html)
+You will still be responsible for configuring your own Azure HA settings within the Azure Portal and the VM-Series firewall. Please refer to the VM-Series deployment guide for 10.1.0 for configuration details. [DEPLOYMENT GUIDE](https://docs.paloaltonetworks.com/vm-series/10-1/vm-series-deployment/set-up-the-vm-series-firewall-on-azure/configure-activepassive-ha-for-vm-series-firewall-on-azure)
 
 
-[<img src="http://azuredeploy.net/deploybutton.png"/>](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSimOnPanw%2FAzure-HA-Deployment%2Fmaster%2Fazuredeploy.json)
+[<img src="http://azuredeploy.net/deploybutton.png"/>](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FPaloAltoNetworks%2FAzure-HA-Deployment%2Fmaster%2Fazuredeploy.json)
 
 # Manual Approach
 
 If you choose to take a different approach you can do the following
 
-1. Launch a VM-Series firewall using the latest which is 9.0(only needed if you don't have an existing VM-Series launched)
+1. Launch a VM-Series firewall using the latest which is 10.1.0 (only needed if you don't have an existing VM-Series launched)
 2. Use Azure CLI to launch a second VM-Series running PAN-OS 8.1 into the exact same Resource Group as the first firewall
 
 For more information on how to use the Azure CLI. [CLICK HERE](https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest)  

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 You will still be responsible for configuring your own Azure HA settings within the Azure Portal and the VM-Series firewall. Please refer to the VM-Series deployment guide for 10.1.0 for configuration details. [DEPLOYMENT GUIDE](https://docs.paloaltonetworks.com/vm-series/10-1/vm-series-deployment/set-up-the-vm-series-firewall-on-azure/configure-activepassive-ha-for-vm-series-firewall-on-azure)
 
 
-[<img src="http://azuredeploy.net/deploybutton.png"/>](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FPaloAltoNetworks%2FAzure-HA-Deployment%2Fmaster%2Fazuredeploy.json)
+[<img src="http://azuredeploy.net/deploybutton.png"/>](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FPaloAltoNetworks%2FAzure-HA-Deployment%2Fmaster%2Fazuredeploy.json?token=AZoiWXZHIcxPcJG4iqbfyOUvHN1O8coUks5ahgGXwA%3D%3D)
 
 # Manual Approach
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 You will still be responsible for configuring your own Azure HA settings within the Azure Portal and the VM-Series firewall. Please refer to the VM-Series deployment guide for 9.0 for configuration details. [DEPLOYMENT GUIDE](https://docs.paloaltonetworks.com/vm-series/9-0/vm-series-deployment/set-up-the-vm-series-firewall-on-azure/configure-activepassive-ha-for-vm-series-firewall-on-azure.html)
 
 
-[<img src="http://azuredeploy.net/deploybutton.png"/>](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FPaloAltoNetworks%2FAzure-HA-Deployment%2Fmaster%2Fazuredeploy.json?token=AZoiWXZHIcxPcJG4iqbfyOUvHN1O8coUks5ahgGXwA%3D%3D)
+[<img src="http://azuredeploy.net/deploybutton.png"/>](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSimOnPanw%2FAzure-HA-Deployment%2Fmaster%2Fazuredeploy.json)
 
 # Manual Approach
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 You will still be responsible for configuring your own Azure HA settings within the Azure Portal and the VM-Series firewall. Please refer to the VM-Series deployment guide for 10.1.0 for configuration details. [DEPLOYMENT GUIDE](https://docs.paloaltonetworks.com/vm-series/10-1/vm-series-deployment/set-up-the-vm-series-firewall-on-azure/configure-activepassive-ha-for-vm-series-firewall-on-azure)
 
 
-[<img src="http://azuredeploy.net/deploybutton.png"/>](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FPaloAltoNetworks%2FAzure-HA-Deployment%2Fmaster%2Fazuredeploy.json?token=AZoiWXZHIcxPcJG4iqbfyOUvHN1O8coUks5ahgGXwA%3D%3D)
+[<img src="http://azuredeploy.net/deploybutton.png"/>](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FPaloAltoNetworks%2FAzure-HA-Deployment%2Fmaster%2Fazuredeploy.json)
 
 # Manual Approach
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -41,6 +41,7 @@
       "type": "string",
       "allowedValues": [
         "latest",
+        "10.2.1",
         "10.1.0",
         "10.0.6",
         "9.1.10"

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -53,26 +53,28 @@
     "vmSize": {
       "type": "string",
       "allowedValues": [
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D3_v2",
-        "Standard_D4_v2",
-        "Standard_D5_v2",
-        "Standard_D3_v3",
-        "Standard_D4_v3",
-        "Standard_D16_v3",
         "Standard_DS3_v2",
         "Standard_DS4_v2",
         "Standard_DS5_v2",
-        "Standard_DS3_v3",
-        "Standard_DS4_v3",
-        "Standard_DS16_v3",
-        "Standard_A4"
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_D4_v3",
+        "Standard_D5_v2",
+        "Standard_D8_v3",
+        "Standard_D8_v4",
+        "Standard_D16_v3",
+        "Standard_D16_v4",
+        "Standard_D8s_v4",
+        "Standard_D16s_v4",
+        "Standard_F8s_v2",
+        "Standard_F32s_v2",
+        "Standard_D8s_v3",
+        "Standard_D16s_v3"
       ],
       "metadata": {
         "description": "Azure VM size for VM-Series"
       },
-      "defaultValue": "Standard_D3_v2"
+      "defaultValue": "Standard_DS3_v2"
     },
     "virtualNetworkName": {
       "type": "string",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -10,18 +10,18 @@
       }
     },
     "srcIPInboundNSG": {
-       "type": "string",
-       "metadata": {
-           "description": "Your source public IP address. Added to the inbound NSG on eth0 (MGMT)"
-       },
-       "defaultValue": "0.0.0.0/0"
+      "type": "string",
+      "metadata": {
+        "description": "Your source public IP address. Added to the inbound NSG on eth0 (MGMT)"
+      },
+      "defaultValue": "0.0.0.0/0"
     },
     "nsgName": {
-       "type": "string",
-       "metadata": {
-           "description": "Name of inbound NSG on eth0 (MGMT).  Name must be unique within Resource Group"
-       },
-       "defaultValue": "DefaultNSG"
+      "type": "string",
+      "metadata": {
+        "description": "Name of inbound NSG on eth0 (MGMT).  Name must be unique within Resource Group"
+      },
+      "defaultValue": "DefaultNSG"
     },
     "customData": {
       "type": "string",
@@ -31,19 +31,19 @@
       }
     },
     "vmName": {
-       "type": "string",
-       "metadata": {
-          "description": "Name of VM-Series VM in the Azure portal"
-       },
-       "defaultValue": "VM-Series"
+      "type": "string",
+      "metadata": {
+        "description": "Name of VM-Series VM in the Azure portal"
+      },
+      "defaultValue": "VM-Series"
     },
     "imageVersion": {
       "type": "string",
       "allowedValues": [
         "latest",
-        "9.0.0",
-        "8.1.0",
-        "8.0.0"
+        "10.1.0",
+        "10.0.6",
+        "9.1.10"
       ],
       "metadata": {
         "description": "Version number of VM-Series VM in the Azure portal"
@@ -51,30 +51,30 @@
       "defaultValue": "latest"
     },
     "vmSize": {
-       "type": "string",
-       "allowedValues": [
-          "Standard_D3",
-          "Standard_D4",
-          "Standard_D3_v2",
-          "Standard_D4_v2",
-          "Standard_D5_v2",
-          "Standard_D3_v3",
-          "Standard_D4_v3",
-          "Standard_D16_v3",
-          "Standard_DS3_v2",
-          "Standard_DS4_v2",
-          "Standard_DS5_v2",
-          "Standard_DS3_v3",
-          "Standard_DS4_v3",
-          "Standard_DS16_v3",
-          "Standard_A4"
-       ],
-       "metadata": {
-          "description": "Azure VM size for VM-Series"
-       },
-       "defaultValue": "Standard_D3_v2"
+      "type": "string",
+      "allowedValues": [
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_D5_v2",
+        "Standard_D3_v3",
+        "Standard_D4_v3",
+        "Standard_D16_v3",
+        "Standard_DS3_v2",
+        "Standard_DS4_v2",
+        "Standard_DS5_v2",
+        "Standard_DS3_v3",
+        "Standard_DS4_v3",
+        "Standard_DS16_v3",
+        "Standard_A4"
+      ],
+      "metadata": {
+        "description": "Azure VM size for VM-Series"
+      },
+      "defaultValue": "Standard_D3_v2"
     },
-    "virtualNetworkName": { 
+    "virtualNetworkName": {
       "type": "string",
       "metadata": {
         "description": "Name of the Virtual Network (VNET)"
@@ -82,15 +82,15 @@
       "defaultValue": "fwVNET"
     },
     "vnetNewOrExisting": {
-            "type": "string",
-            "defaultValue": "new",
-            "allowedValues": [
-                "new",
-                "existing"
-            ],
-            "metadata": {
-                "description": "Use new or existing VNET"
-            }
+      "type": "string",
+      "defaultValue": "new",
+      "allowedValues": [
+        "new",
+        "existing"
+      ],
+      "metadata": {
+        "description": "Use new or existing VNET"
+      }
     },
     "virtualNetworkAddressPrefix": {
       "type": "string",
@@ -145,15 +145,15 @@
       }
     },
     "authenticationType": {
-            "type": "string",
-            "metadata": {
-                "description": "Type of administrator user authentication "
-            },
-            "allowedValues": [
-                "sshPublicKey",
-                "password"
-            ],
-            "defaultValue": "password"
+      "type": "string",
+      "metadata": {
+        "description": "Type of administrator user authentication "
+      },
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "defaultValue": "password"
     },
     "adminUsername": {
       "type": "string",
@@ -212,7 +212,7 @@
     },
     "bootstrap": {
       "type": "string",
-      "defaultValue" : "no",
+      "defaultValue": "no",
       "allowedValues": [
         "yes",
         "no"
@@ -223,28 +223,28 @@
     },
     "zone": {
       "type": "string",
-      "defaultValue" : "None",
+      "defaultValue": "None",
       "metadata": {
         "description": "Availability Zone for VM-Series"
       }
     },
     "availabilitySetName": {
       "type": "string",
-      "defaultValue" : "None"
+      "defaultValue": "None"
     },
     "availabilitySetPlatformFaultDomainCount": {
       "type": "string",
-      "defaultValue" : "2"
+      "defaultValue": "2"
     },
     "availabilitySetPlatformUpdateDomainCount": {
       "type": "string",
-      "defaultValue" : "5"
+      "defaultValue": "5"
     }
   },
   "variables": {
     "imagePublisher": "paloaltonetworks",
-    "imageSku" : "byol",
-    "imageOffer" : "vmseries1",
+    "imageSku": "byol",
+    "imageOffer": "vmseries-flex",
     "nicName": "[concat(parameters('vmName'), '-', parameters('publicIPAddressName'), '-eth')]",
     "existingVnetID": "[resourceId(parameters('virtualNetworkExistingRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
     "existingSubnet0Ref": "[concat(variables('existingVnetID'),'/subnets/',parameters('subnet0Name'))]",
@@ -281,7 +281,7 @@
         "properties": {
           "addressPrefix": "[parameters('subnet0Prefix')]",
           "networkSecurityGroup": {
-              "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
+            "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
           }
         }
       },
@@ -332,46 +332,50 @@
       "apiVersion": "2017-10-01",
       "location": "[parameters('location')]",
       "properties": {
-        "securityRules": [{
-          "name": "Allow-Outside-From-IP",
-          "properties": {
-            "description": "Rule",
-            "protocol": "*",
-            "sourcePortRange": "*",
-            "destinationPortRange": "*",
-            "sourceAddressPrefix": "[parameters('srcIPInboundNSG')]",
-            "destinationAddressPrefix": "*",
-            "access": "Allow",
-            "priority": 100,
-            "direction": "Inbound"
+        "securityRules": [
+          {
+            "name": "Allow-Outside-From-IP",
+            "properties": {
+              "description": "Rule",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "[parameters('srcIPInboundNSG')]",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-Intra",
+            "properties": {
+              "description": "Allow intra network traffic",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "[parameters('virtualNetworkAddressPrefix')]",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 101,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Default-Deny",
+            "properties": {
+              "description": "Default-Deny if we don't match Allow rule",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Deny",
+              "priority": 200,
+              "direction": "Inbound"
+            }
           }
-        }, {
-          "name": "Allow-Intra",
-          "properties": {
-            "description": "Allow intra network traffic",
-            "protocol": "*",
-            "sourcePortRange": "*",
-            "destinationPortRange": "*",
-            "sourceAddressPrefix": "[parameters('virtualNetworkAddressPrefix')]",
-            "destinationAddressPrefix": "*",
-            "access": "Allow",
-            "priority": 101,
-            "direction": "Inbound"
-          }
-        }, {
-          "name": "Default-Deny",
-          "properties": {
-            "description": "Default-Deny if we don't match Allow rule",
-            "protocol": "*",
-            "sourcePortRange": "*",
-            "destinationPortRange": "*",
-            "sourceAddressPrefix": "*",
-            "destinationAddressPrefix": "*",
-            "access": "Deny",
-            "priority": 200,
-            "direction": "Inbound"
-          }
-        }]
+        ]
       }
     },
     {
@@ -505,46 +509,50 @@
         "publisher": "[variables('imagePublisher')]"
       },
       "properties": {
-          "hardwareProfile": {
-              "vmSize": "[parameters('vmSize')]"
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]",
+          "customData": "[if(equals(parameters('bootstrap'), 'no'), json('null'), base64(parameters('customData')))]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('imageSku')]",
+            "version": "[parameters('imageVersion')]"
           },
-          "osProfile": {
-              "computerName": "[parameters('vmName')]",
-              "adminUsername": "[parameters('adminUsername')]",
-              "adminPassword": "[parameters('adminPassword')]",
-              "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]",
-              "customData": "[if(equals(parameters('bootstrap'), 'no'), json('null'), base64(parameters('customData')))]"
-          },
-          "storageProfile": {
-              "imageReference": {
-                  "publisher": "[variables('imagePublisher')]",
-                  "offer": "[variables('imageOffer')]",
-                  "sku": "[variables('imageSku')]",
-                  "version": "[parameters('imageVersion')]"
-              },
-              "osDisk": {
-                  "createOption": "FromImage"
+          "osDisk": {
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'),'0'))]",
+              "properties": {
+                "primary": true
               }
-          },
-          "networkProfile": {
-              "networkInterfaces": [{
-                  "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'),'0'))]",
-                  "properties": {
-                      "primary": true
-                  }
-              }, {
-                  "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'),'1'))]",
-                  "properties": {
-                      "primary": false
-                  }
-              }, {
-                  "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'),'2'))]",
-                  "properties": {
-                      "primary": false
-                  }
-              }]
-          },
-          "availabilitySet": "[if(equals(parameters('availabilitySetName'), 'None'), json('null'), variables('availabilitySet'))]"
+            },
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'),'1'))]",
+              "properties": {
+                "primary": false
+              }
+            },
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'),'2'))]",
+              "properties": {
+                "primary": false
+              }
+            }
+          ]
+        },
+        "availabilitySet": "[if(equals(parameters('availabilitySetName'), 'None'), json('null'), variables('availabilitySet'))]"
       },
       "zones": "[if(equals(parameters('zone'), 'None'), json('null'), variables('zones'))]"
     }

--- a/parameters.json
+++ b/parameters.json
@@ -30,10 +30,10 @@
             "value": "ADMIN-SSHKEY"
         },
         "vmSize": {
-            "value": "Standard_D3_v2"
+            "value": "Standard_DS3_v2"
         },
         "imageVersion": {
-            "value": "8.1.0"
+            "value": "10.1.0"
         },
         "srcIPInboundNSG": {
             "value": "0.0.0.0/0"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add support to 10.1.0 version and change the imageOffer to vmseries-flex.
We could easily add PAYG option for bundle 1 and 2.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Customer reached out to me to update this template with the new panos versions.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I have deployed a VM on my azure envritoment and asked the customer to test in his azure tenant, Customer confirmed that it was working fine.
<!--- Include details of your testing environment, and the tests you ran to -->
Click on the button in the repo that loads the azuredeploy.json and parameters.json files.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
